### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "./snake.sh"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/pjhades/bash-snake)](https://repl.it/github/pjhades/bash-snake)
+
 About
 ---------------
 A simple snake game written in Bash.


### PR DESCRIPTION
It's really easy to play this in the browser through repl.it, this pull configures that. Would you consider adding the badge?
![Capture](https://user-images.githubusercontent.com/39810066/70551165-02175b80-1b45-11ea-954e-501c59391aff.PNG)
It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/bash-snake).